### PR TITLE
Mark all objects in scene as static objects to avoid wrong inertia in physics simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,13 @@ Below is a table showing portrait type to picture resolution data and custom ima
 | PortraitD_02 | 1024x450 | |
 | PortraitE_01 | 700x1024 | maggie |
 | PortraitE_02 | 700x1024 | iftach |
+
+# Disclaimer
+
+All objects in the scene should be static objects as intended for this sample app.
+If there is a need for some of objects to be non-static, change their 'static' flag in the world file to 'false', 
+and make sure they have correct mass and inertia values in their model.sdf
+Link: http://gazebosim.org/tutorials?tut=inertia&cat=build_robot
+
+Currently, objects in scene have inconsistent mass and inertia values, they will be fixed in the future change.
+Inconsistent mass and inertia should not affect static object simulation.

--- a/worlds/small_house.world
+++ b/worlds/small_house.world
@@ -34,7 +34,8 @@
       <heading_deg>0</heading_deg>
     </spherical_coordinates>
 
-    <model name='AirconditionerA_01_001'>
+  <model name='AirconditionerA_01_001'>
+        <static>true</static>
         <include>
             <uri>model://aws_robomaker_residential_AirconditionerA_01</uri>
         </include>
@@ -42,12 +43,14 @@
 	</model>
 	
 	<model name='AirconditionerB_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_AirconditionerB_01</uri>
         </include>
         <pose frame=''>-2.004656 -5.226610 0.003485 0 -0 0</pose>
 	</model>
 	<model name='Ball_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_Ball_01</uri>
         </include>
@@ -65,31 +68,36 @@
     -->
 
     <!-- bedroom ball -->
-    <model name='Ball_01_003'>
+  <model name='Ball_01_003'>
+        <static>true</static>      
         <include>
             <uri>model://aws_robomaker_residential_Ball_01</uri>
         </include>
         <pose frame=''>-6.945503 -4.22174 0.318684 0 -0 0</pose>
 	</model>
 	<model name='Bed_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_Bed_01</uri>
         </include>
         <pose frame=''>-6.165067 2.030560 -0.000010 0 -0 0</pose>
 	</model>
 	<model name='NightStand_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_NightStand_01</uri>
         </include>
         <pose frame=''>-7.725510 2.860420 0.005258 -0.000002 0 0</pose>
 	</model>
 	<model name='NightStand_01_002'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_NightStand_01</uri>
         </include>
         <pose frame=''>-4.407341 2.860420 0.005256 0 0.000002 0</pose>
 	</model>
 	<model name='Board_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_Board_01</uri>
         </include>
@@ -98,6 +106,7 @@
 	
     <!-- Remove ceiling for easier view
 	<model name='RoomCeiling_01_001'>
+        <static>true</static>
         <include>
             <uri>model://aws_robomaker_residential_RoomCeiling_01</uri>
         </include>
@@ -106,96 +115,112 @@
     -->
 	
 	<model name='ChairA_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_ChairA_01</uri>
         </include>
         <pose frame=''>7.11516 0.209028 0.024685 1e-06 -0 -1.55607</pose>
 	</model>
 	<model name='ChairA_01_002'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_ChairA_01</uri>
         </include>
         <pose frame=''>6.25506 0.219468 0.011308 0 0 -1.50414</pose>
 	</model>
 	<model name='ChairA_01_003'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_ChairA_01</uri>
         </include>
         <pose frame=''>6.06678 1.68075 0.01 0 -0 1.56986</pose>
 	</model>
 	<model name='ChairA_01_004'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_ChairA_01</uri>
         </include>
         <pose frame=''>7.00277 1.67074 0 0 -0 1.52363</pose>
 	</model>
 	<model name='ChairA_01_005'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_ChairA_01</uri>
         </include>
         <pose frame=''>-8.270940 1.916650 0.036650 0 -0 0</pose>
 	</model>
 	<model name='ChairD_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_ChairD_01</uri>
         </include>
         <pose frame=''>-1.380775 4.104456 0 0 -0 0</pose>
 	</model>
 	<model name='ChairD_01_002'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_ChairD_01</uri>
         </include>
         <pose frame=''>0.325214 4.104456 0 0 -0 -3.138741</pose>
 	</model>
     <model name='ChairD_01_003'>
+        <static>true</static>      
         <include>
             <uri>model://aws_robomaker_residential_ChairD_01</uri>
         </include>
         <pose frame=''>-8.270775 -4.504456 0 0 -0 0.869673</pose>
 	</model>
 	<model name='Chandelier_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_Chandelier_01</uri>
         </include>
         <pose frame=''>1.221061 4.155740 1.295000 0 -0 0</pose>
 	</model>
-       	<model name='Chandelier_01_002'>
+  <model name='Chandelier_01_002'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_Chandelier_01</uri>
         </include>
         <pose frame=''>-6.451061 -0.692040 1.810000 0 -0 0</pose>
 	</model>
 	<model name='Chandelier_01_003'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_Chandelier_01</uri>
         </include>
         <pose frame=''>7.824061 -1.59 1.7510000 0 -0 0</pose>
 	</model>
-    <model name='Chandelier_01_004'>
+  <model name='Chandelier_01_004'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_Chandelier_01</uri>
         </include>
         <pose frame=''>1.221061 -1.592040 1.7873000 0 -0 0</pose>
 	</model>
 	<model name='Carpet_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_Carpet_01</uri>
         </include>
         <pose frame=''>0.785050 -1.106647 0.001106 0 -0 0</pose>
 	</model>
     <model name='Carpet_01_002'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_Carpet_01</uri>
         </include>
         <pose frame=''>2.854050 3.45 0.000585 0 -0 0</pose>
 	</model>
 	<model name='SecurityCamera_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_SecurityCamera_01</uri>
         </include>
         <pose frame=''>0.842134 -4.996294 0.495067 0 -0 -2.841039</pose>
 	</model>
 	<model name='CoffeeTable_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_CoffeeTable_01</uri>
         </include>
@@ -210,6 +235,7 @@
 	</model>
 
 	<model name='Curtain_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_Curtain_01</uri>
         </include>
@@ -217,18 +243,21 @@
 	</model>
     
 	<model name='KitchenTable_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_KitchenTable_01</uri>
         </include>
         <pose frame=''>6.55269 0.951173 -0.000006 0 -0 -1.564130</pose>
 	</model>
 	<model name='ReadingDesk_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_ReadingDesk_01</uri>
         </include>
         <pose frame=''>-8.987262 2.057058 0 0 -0 -0.004638</pose>
 	</model>
 	<model name='BalconyTable_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_BalconyTable_01</uri>
         </include>
@@ -236,6 +265,7 @@
 	</model>
 
 	<model name='Door_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_Door_01</uri>
         </include>
@@ -243,36 +273,42 @@
 	</model>
 	
 	<model name='Dumbbell_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_Dumbbell_01</uri>
         </include>
         <pose frame=''>2.512849 2.717787 0.002183 0 -0 0</pose>
 	</model>
 	<model name='Tablet_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_Tablet_01</uri>
         </include>
         <pose frame=''>1.572830 -1.775857 0.401790 -0.020625 -0.000080 -0.006317</pose>
 	</model>
 	<model name='FitnessEquipment_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_FitnessEquipment_01</uri>
         </include>
         <pose frame=''>3.484720 3.169104 0.003168 0 -0 0</pose>
 	</model>
 	<model name='FoldingDoor_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_FoldingDoor_01</uri>
         </include>
         <pose frame=''>-2.461096 1.844219 0.041881 0 -0 0</pose>
 	</model>
 	<model name='FoldingDoor_01_002'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_FoldingDoor_01</uri>
         </include>
         <pose frame=''>-2.461096 -4.053320 0.041881 0 -0 0</pose>
 	</model>
 	<model name='Handle_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_Handle_01</uri>
         </include>
@@ -280,6 +316,7 @@
 	</model>
 	
     <model name='HouseWallB_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_HouseWallB_01</uri>
         </include>
@@ -287,6 +324,7 @@
 	</model>
     
     <model name='FloorB_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_FloorB_01</uri>
         </include>
@@ -295,6 +333,7 @@
 
 
     <model name='FoldingDoor_02_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_FoldingDoor_02</uri>
         </include>
@@ -302,6 +341,7 @@
 	</model>
 
     <model name='FoldingDoor_02_002'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_FoldingDoor_02</uri>
         </include>
@@ -309,12 +349,14 @@
 	</model>
 
 	<model name='KitchenCabinet_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_KitchenCabinet_01</uri>
         </include>
         <pose frame=''>8.002009 -3.836509 0.012068 0 -0 -3.140001</pose>
 	</model>
 	<model name='KitchenUtensils_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_KitchenUtensils_01</uri>
         </include>
@@ -322,12 +364,14 @@
 	</model>
 	
 	<model name='LightC_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_LightC_01</uri>
         </include>
         <pose frame=''>1.769567 -5.4443710 2.000000 0 -0 0</pose>
 	</model>
 	<model name='LightC_01_002'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_LightC_01</uri>
         </include>
@@ -344,6 +388,7 @@
     -->
      <!-- WALL -->
 	<model name='PortraitA_01'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_PortraitA_01</uri>
         </include>
@@ -351,6 +396,7 @@
 	</model>
 	
 	<model name='PortraitB_01'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_PortraitB_01</uri>
         </include>
@@ -358,6 +404,7 @@
 	</model>
 
 	<model name='PortraitB_02'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_PortraitB_02</uri>
         </include>
@@ -365,6 +412,7 @@
 	</model>
 
 	<model name='PortraitB_03'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_PortraitB_03</uri>
         </include>
@@ -372,6 +420,7 @@
 	</model>
 
 	<model name='PortraitA_02'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_PortraitA_02</uri>
         </include>
@@ -379,6 +428,7 @@
 	</model>
 
 	<model name='PortraitC_01'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_PortraitC_01</uri>
         </include>
@@ -386,12 +436,14 @@
 	</model>
 	
 	<model name='PortraitD_01'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_PortraitD_01</uri>
         </include>
         <pose frame=''>0.789763 -5.478725 1.800000 0 -0 3.138531</pose>
 	</model>
 	<model name='PortraitD_02'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_PortraitD_02</uri>
         </include>
@@ -399,12 +451,14 @@
 	</model>
 	
 	<model name='PortraitE_01'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_PortraitE_01</uri>
         </include>
         <pose frame=''>-5.773094 -5.492466 1.000000 0 -0 3.132627</pose>
 	</model>
 	<model name='PortraitE_02'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_PortraitE_02</uri>
         </include>
@@ -413,12 +467,14 @@
 
     <!-- DESK -->
 	<model name='DeskPortraitA_01'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_DeskPortraitA_01</uri>
         </include>
         <pose frame=''>-0.036864 -5.110156 0.498660 0 -0 2.927784</pose>
 	</model>
     <model name='DeskPortraitA_02'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_DeskPortraitA_02</uri>
         </include>
@@ -426,48 +482,56 @@
         <pose frame=''>2.046082 -1.892926 0.0703880 -0.018328 -0.000441 1.576216</pose>
 	</model>
 	<model name='DeskPortraitC_01'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_DeskPortraitC_01</uri>
         </include>
         <pose frame=''>-7.746377 2.731075 0.694620 0.000488 -0.000359 -0.055499</pose>
 	</model>
         <model name='DeskPortraitC_02'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_DeskPortraitC_02</uri>
         </include>
         <pose frame=''>0.964613 -1.586951 0.127676 0.001614 -0.000545 -1.578699</pose>
 	</model>
 	<model name='DeskPortraitD_01'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_DeskPortraitD_01</uri>
         </include>
         <pose frame=''>2.645560 -5.376225 1.573738 0 -0 -3.112826</pose>
 	</model>
         <model name='DeskPortraitD_02'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_DeskPortraitD_02</uri>
         </include>
         <pose frame=''>-0.589211 -5.109890 0.192145 -0.000015 -0.000174 -3.112544</pose>
 	</model>
         <model name='DeskPortraitD_03'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_DeskPortraitD_03</uri>
         </include>
         <pose frame=''>1.826729 -1.464881 0.126208 0.000010 0.000006 -3.114380</pose>
 	</model>
     <model name='DeskPortraitD_04'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_DeskPortraitD_04</uri>
         </include>
         <pose frame=''>4.302132 -5.176568 0.202496 0.007118 -0.000001 3.046683</pose>
 	</model>
        <model name='DeskPortraitB_01'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_DeskPortraitB_01</uri>
         </include>
 	<pose frame=''>3.547376 -5.083898 -0.012660 -0.336622 -0.000001 3.046741</pose>
 	</model>
     <model name='DeskPortraitB_02'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_DeskPortraitB_02</uri>
         </include>
@@ -476,6 +540,7 @@
     <!-- Wall & Desk Portraits END -->
 
 	<model name='Rangehood_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_Rangehood_01</uri>
         </include>
@@ -483,60 +548,70 @@
 	</model>
 	
 	<model name='Refrigerator_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_Refrigerator_01</uri>
         </include>
         <pose frame=''>8.702731 -1.032031 0 0 -0 -1.563499</pose>
 	</model>
 	<model name='SeasoningBox_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_SeasoningBox_01</uri>
         </include>
         <pose frame=''>9.107968 -2.651726 0.902458 -0.000006 0.000034 0.001290</pose>
 	</model>
 	<model name='ShoeRack_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_ShoeRack_01</uri>
         </include>
         <pose frame=''>4.297978 -5.173566 0 0 -0 0</pose>
 	</model>
 	<model name='SofaC_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_SofaC_01</uri>
         </include>
         <pose frame=''>0.775898 -0.411153 0.065992 -0.000464 -0.000071 0.005614</pose>
 	</model>
 	<model name='Tableware_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_Tableware_01</uri>
         </include>
         <pose frame=''>7.15317 0.982767 0.817812 -0.001238 -0.000976 1.02476</pose>
 	</model>
 	<model name='Trash_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_Trash_01</uri>
         </include>
         <pose frame=''>2.360151 -0.796238 0.011 0 -0 0</pose>
 	</model>
     <model name='Trash_01_002'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_Trash_01</uri>
         </include>
         <pose frame=''>-8.704151 1.00058 0.011 0 -0 0</pose>
 	</model>
 	<model name='TV_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_TV_01</uri>
         </include>
         <pose frame=''>0.824259 -5.382968 0.676282 0 -0 -1.561744</pose>
 	</model>
 	<model name='TV_02_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_TV_02</uri>
         </include>
         <pose frame=''>-6.197322 -1.388739 0.676282 0 -0 -1.561744</pose>
 	</model>	
 	<model name='TVCabinet_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_TVCabinet_01</uri>
         </include>
@@ -546,12 +621,14 @@
         <pose frame=''>0.629509 -5.183576 -0.017049 0 -0 1.5792</pose>
 	</model>
 	<model name='Vase_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_Vase_01</uri>
         </include>
         <pose frame=''>3.055663 -5.413080 1.574958 0.000003 0.001700 0.000840</pose>
 	</model>`
 	<model name='RoomWall_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_RoomWall_01</uri>
         </include>
@@ -561,60 +638,70 @@
 
 	
 	<model name='Wardrobe_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_Wardrobe_01</uri>
         </include>
         <pose frame=''>-3.146710 2.476204 0.000704 0 -0 -1.569673</pose>
 	</model>
         <model name='RoomWindow_01_001'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_RoomWindow_01</uri>
         </include>
         <pose frame=''>-9.418600 -0.026285 0.502739 0 -0 0</pose>
 	</model>
 	<model name='RoomWindow_01_002'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_RoomWindow_01</uri>
         </include>
         <pose frame=''>-9.418600 -2.374090 0.502739 0 -0 0</pose>
 	</model>
 	<model name='RoomWindow_01_003'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_RoomWindow_01</uri>
         </include>
         <pose frame=''>9.422616 -3.373981 0.502739 0 -0 -3.136099</pose>
 	</model>
 	<model name='RoomWindow_01_004'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_RoomWindow_01</uri>
         </include>
         <pose frame=''>9.422558 0.968520 0.496581 0 -0 -3.136099</pose>
 	</model>
 	<model name='RoomWindow_01_005'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_RoomWindow_01</uri>
         </include>
         <pose frame=''>4.722317 4.470281 0.502739 0 -0 -3.136099</pose>
 	</model>
 	<model name='RoomWindow_01_006'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_RoomWindow_01</uri>
         </include>
         <pose frame=''>3.488520 5.600688 0.502739 0 -0 -1.566274</pose>
 	</model>
 	<model name='RoomWindow_01_007'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_RoomWindow_01</uri>
         </include>
         <pose frame=''>1.140949 5.600688 0.502739 0 -0 -1.566274</pose>
 	</model>
 	<model name='RoomWindow_01_008'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_RoomWindow_01</uri>
         </include>
         <pose frame=''>-1.199340 5.600688 0.502739 0 -0 -1.566274</pose>
 	</model>
 	<model name='RoomWindow_01_009'>
+        <static>true</static>    
         <include>
             <uri>model://aws_robomaker_residential_RoomWindow_01</uri>
         </include>


### PR DESCRIPTION
- Objects in sample app should be static as intended for this sample app
- Static objects will not be simulated in physics engine (except collision detection)
- If there is a need for some objects to be non-static, change static flag to "true" for those objects and make sure they have correct mass(s) and inertia(s)
- Objects' mass and inertia do not have correct values, they will be corrected in the future change

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
