### PR TITLE
Fixes for using ROS2

### DIFF
--- a/models/aws_robomaker_residential_DeskPortraitC_01/model.sdf
+++ b/models/aws_robomaker_residential_DeskPortraitC_01/model.sdf
@@ -16,7 +16,7 @@
       <collision name="collision">
         <geometry>
           <mesh>
-            <uri>model://models/aws_robomaker_residential_DeskPortraitC_01/meshes/aws_DeskPortraitC_01_collision.DAE</uri>
+            <uri>model://aws_robomaker_residential_DeskPortraitC_01/meshes/aws_DeskPortraitC_01_collision.DAE</uri>
             <scale>1 1 1</scale>
           </mesh>
         </geometry>
@@ -24,7 +24,7 @@
       <visual name="visual">
 	    <geometry>
           <mesh>
-            <uri>model://models/aws_robomaker_residential_DeskPortraitC_01/meshes/aws_DeskPortraitC_01_visual.DAE</uri>
+            <uri>model://aws_robomaker_residential_DeskPortraitC_01/meshes/aws_DeskPortraitC_01_visual.DAE</uri>
           </mesh>
         </geometry>
       <meta> <layer> 1 </layer></meta>

--- a/package.xml
+++ b/package.xml
@@ -12,8 +12,6 @@
   <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>gazebo</exec_depend>
   <exec_depend>gazebo_plugins</exec_depend>
-  <exec_depend>turtlebot3_description</exec_depend>
-  <exec_depend>turtlebot3_navigation2</exec_depend>
 
   <export>
    <build_type>ament_cmake</build_type>


### PR DESCRIPTION
When I tried to use the AWS small house, it took a long time to load the environment because the model path for aws_DeskPortraitC_01 model was wrong. I fixed the path and removed the turtlebot3 dependencies that are not needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
