### PR TITLE
Remove Tutlebot env variable export step

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ colcon build
 
 # run in ROS
 source install/setup.sh
-export TURTLEBOT3_MODEL=waffle_pi
 ros2 launch aws_robomaker_small_house_world small_house.launch.py gui:=true
 ```
 


### PR DESCRIPTION
Removing turtlebot related instructions since we don't have any dependency on turtlebot

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
